### PR TITLE
Fix incorrect version (0.7) in README.md to correct version (0.7.0) a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Maven
 <dependency>
   <groupId>com.netflix.spinnaker.embedded-redis</groupId>
   <artifactId>embedded-redis</artifactId>
-  <version>0.7</version>
+  <version>0.7.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
…ccording to maven repository.

There is no artifact with version 0.7 but there is the artifact with version 0.7.0